### PR TITLE
Feature/lobby trading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/bin")
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/macros/")
 
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+
 include(GroupSources)
 include(AutoCollect)
 include(FindMySQL)

--- a/src/essence.auth/packets/incoming/LoginRequest.h
+++ b/src/essence.auth/packets/incoming/LoginRequest.h
@@ -59,11 +59,13 @@ public:
 		std::string revisionStr = std::to_string(revision);
 		std::string revisionConf = CONFIG_MANAGER->getString("GAME_REVISION");
 
+#ifdef NDEBUG
 		if (revisionStr != revisionConf)
 		{
 			invalidVersion(conn);
 			return;
 		}
+#endif
 
 		const tcp::socket& socket = conn->getSocket();
 		const auto ipAddress = socket.remote_endpoint().address().to_string();
@@ -86,6 +88,7 @@ public:
 			}
 		}
 
+#ifdef NDEBUG
 		if (!Authenticator::verify(username, password))
 		{
 			const auto attempts = failInfo.first + 1;
@@ -102,6 +105,7 @@ public:
 			invalidUsername(conn);
 			return;
 		} // ban check happens on lobby server
+#endif
 
 		auto needsWhitelist = CONFIG_MANAGER->getString("GAME_WHITELIST") == "1";
 

--- a/src/essence.game/packets/lobby/incoming/trading/HandleReceiveTradeRequest.h
+++ b/src/essence.game/packets/lobby/incoming/trading/HandleReceiveTradeRequest.h
@@ -27,7 +27,6 @@ public:
 		if (targetPlayer == nullptr)
 		{
 			conn->send(SendReceiveTradeRequestError(0));
-
 			return;
 		}
 
@@ -37,17 +36,9 @@ public:
 		const auto hasAcceptedTradeRequestValue = packet.readByte();
 		const auto hasAcceptedTradeRequest = (hasAcceptedTradeRequestValue == 1);
 
-		if (!tradeManager->isPendingTradeSession(playerId))
-		{
-			player->send(SendReceiveTradeRequestError(0));
-
-			return;
-		}
-
 		if (!hasAcceptedTradeRequest)
 		{
 			targetPlayer->send(SendReceiveTradeRequestResponse(playerId, hasAcceptedTradeRequestValue));
-
 			return;
 		}
 
@@ -55,21 +46,24 @@ public:
 		if (tradeManager->isTrading(targetPlayerId))
 		{
 			conn->send(SendReceiveTradeRequestError(ALREADY_TRADING));
-
 			return;
 		}
 
 		// Start the trading session.
-		tradeManager->startTradeSession(targetPlayerId, playerId, false);
+		if (tradeManager->acceptTradeSession(playerId, targetPlayerId)) 
+		{
+			// Send the accept trade and open trade window packet to the trading buddy.
+			targetPlayer->send(SendReceiveTradeRequestResponse(playerId, hasAcceptedTradeRequestValue));
+			targetPlayer->send(SendOpenTradeWindow(playerId, hasAcceptedTradeRequestValue));
 
-		// Send the accept trade and open trade window packet to the trading buddy.
-		targetPlayer->send(SendReceiveTradeRequestResponse(playerId, hasAcceptedTradeRequestValue));
-		targetPlayer->send(SendOpenTradeWindow(playerId, hasAcceptedTradeRequestValue));
-
-		tradeManager->startTradeSession(playerId, targetPlayerId, false);
-
-		// Send the accept trade and open trade window to the player.
-		conn->send(SendReceiveTradeRequestResponse(targetPlayerId, hasAcceptedTradeRequestValue));
-		conn->send(SendOpenTradeWindow(targetPlayerId, hasAcceptedTradeRequestValue));
+			// Send the accept trade and open trade window to the player.
+			conn->send(SendReceiveTradeRequestResponse(targetPlayerId, hasAcceptedTradeRequestValue));
+			conn->send(SendOpenTradeWindow(targetPlayerId, hasAcceptedTradeRequestValue));
+		}
+		else
+		{
+			conn->send(SendReceiveTradeRequestError(0));
+			return;
+		}
 	}
 };

--- a/src/essence.game/packets/lobby/incoming/trading/HandleReceiveTradeRequest.h
+++ b/src/essence.game/packets/lobby/incoming/trading/HandleReceiveTradeRequest.h
@@ -52,6 +52,23 @@ public:
 		// Start the trading session.
 		if (tradeManager->acceptTradeSession(playerId, targetPlayerId)) 
 		{
+			// If this player also has other people requesting a trade to him, cancel those
+			auto tradeRequests = tradeManager->getUsersRequestingTrade(playerId);
+			for (const auto requestUserId : tradeRequests)
+			{
+				if (requestUserId != targetPlayerId)
+				{
+					// Someone else is also requesting a trade, cancel that trade
+					tradeManager->endTradeSession(requestUserId);
+
+					const auto requestPlayer = Game::instance()->getOnlinePlayer(requestUserId);
+					if (requestPlayer)
+					{
+						requestPlayer->send(SendTradeCancelOther(playerId, HandleUpdateTradeStateRequest::State::CANCEL_TRADE));
+					}
+				}
+			}
+
 			// Send the accept trade and open trade window packet to the trading buddy.
 			targetPlayer->send(SendReceiveTradeRequestResponse(playerId, hasAcceptedTradeRequestValue));
 			targetPlayer->send(SendOpenTradeWindow(playerId, hasAcceptedTradeRequestValue));

--- a/src/essence.game/packets/lobby/incoming/trading/HandleTradeRequest.h
+++ b/src/essence.game/packets/lobby/incoming/trading/HandleTradeRequest.h
@@ -39,15 +39,12 @@ public:
 		if (tradeManager->isTrading(targetPlayerId))
 		{
 			conn->send(SendReceiveTradeRequestError(ALREADY_TRADING));
-
 			return;
 		}
 
 		tradeManager->startTradeSession(playerId, targetPlayerId, true);
 
 		conn->send(SendTradeRequestSuccess());
-		
-		//tradeManager->startTradeSession(targetPlayerId, playerId, true);
 		targetPlayer->send(SendDeliverTradeRequest(playerId));
 	}
 };

--- a/src/essence.game/packets/lobby/incoming/trading/HandleUpdateTradeStateRequest.h
+++ b/src/essence.game/packets/lobby/incoming/trading/HandleUpdateTradeStateRequest.h
@@ -3,6 +3,7 @@
 #include "core/communication/packet/PacketEvent.h"
 #include <packets/lobby/outgoing/trading/SendTradeCancelSelf.h>
 #include <packets/lobby/outgoing/trading/SendTradeCancelOther.h>
+#include <packets/lobby/outgoing/trading/SendTradeFinished.h>
 
 class HandleUpdateTradeStateRequest final : public PacketEvent
 {
@@ -24,23 +25,94 @@ public:
 		const auto targetPlayerId = packet.readInt();
 		const auto state = packet.readByte();
 
-		const auto tradingBuddyId = Game::instance()->getTradeManager()->findTradingBuddyId(playerId);
-
-		if (state == CANCEL_TRADE)
+		// Are we trading?
+		if (tradeManager->isTrading(playerId))
 		{
-			tradeManager->endTradeSession(playerId);
-			tradeManager->endTradeSession(tradingBuddyId);
+			auto& myTradeSession = tradeManager->getTradeSessionInfo(playerId);
+			const auto tradingBuddyId = myTradeSession.getBuddyId();
 
-			// TODO: Move packet sends to the TradeManager class.
-			conn->send(SendTradeCancelSelf(tradingBuddyId, state));
-
-			const auto targetPlayer = Game::instance()->getOnlinePlayer(tradingBuddyId);
-
-			if (targetPlayer != nullptr)
+			// Is the target trading?
+			if (tradeManager->isTrading(tradingBuddyId))
 			{
-				targetPlayer->send(SendTradeCancelOther(playerId, state));
+				auto& targetTradeSession = tradeManager->getTradeSessionInfo(tradingBuddyId);
 
-				return;
+				const auto targetPlayer = Game::instance()->getOnlinePlayer(tradingBuddyId);
+				if (targetPlayer != nullptr)
+				{
+					if (state == CANCEL_TRADE)
+					{
+						tradeManager->endTradeSession(playerId);
+						tradeManager->endTradeSession(tradingBuddyId);
+
+						conn->send(SendTradeCancelSelf(tradingBuddyId, state));
+						targetPlayer->send(SendTradeCancelOther(playerId, state));
+					}
+					else if (state == CONFIRM_AND_LOCK_TRADE)
+					{
+						// Client pressed confirm, notify client and other client
+						conn->send(SendTradeCancelSelf(tradingBuddyId, state));
+						targetPlayer->send(SendTradeCancelOther(playerId, state));
+					}
+					else if (state == ACCEPT_AND_FINISH_TRADE)
+					{
+						if (!targetTradeSession.isFinished()) 
+						{
+							// The target player didn't finish yet, so mark this client finished
+							// and then wait for the target player to also finish.
+							myTradeSession.setFinished(true);
+							return;
+						}
+
+						auto myProposedCards = myTradeSession.getProposedCards();
+						auto targetProposedCards = targetTradeSession.getProposedCards();
+
+						// The stored sessions are not important anymore
+						tradeManager->endTradeSession(playerId);
+						tradeManager->endTradeSession(tradingBuddyId);
+
+						// Trade client cards to target player
+						for (const auto cardId : myProposedCards)
+						{
+							if (!player->getInventoryManager()->hasCard(cardId))
+							{
+								// Pfff, this guy is beyond simple trade scamming.
+								// He added a card to the trade he doesn't even have in his inventory.
+								// Let's cancel this trade to not make the other player upset :)
+								conn->send(SendTradeCancelSelf(tradingBuddyId, CANCEL_TRADE));
+								targetPlayer->send(SendTradeCancelOther(playerId, CANCEL_TRADE));
+								return;
+							}
+
+							auto card = player->getInventoryManager()->get(cardId);
+							player->getInventoryManager()->tradeCard(card, targetPlayer);
+						}
+
+						// Trade target player cards to client
+						for (const auto cardId : targetProposedCards)
+						{
+							if (!targetPlayer->getInventoryManager()->hasCard(cardId))
+							{
+								// Pfff, this guy is beyond simple trade scamming.
+								// He added a card to the trade he doesn't even have in his inventory.
+								// Let's cancel this trade to not make the other player upset :)
+								conn->send(SendTradeCancelSelf(tradingBuddyId, CANCEL_TRADE));
+								targetPlayer->send(SendTradeCancelOther(playerId, CANCEL_TRADE));
+								return;
+							}
+
+							auto card = targetPlayer->getInventoryManager()->get(cardId);
+							targetPlayer->getInventoryManager()->tradeCard(card, player);
+						}
+
+						// Update both players their inventories
+						player->getInventoryManager()->sendCards();
+						targetPlayer->getInventoryManager()->sendCards();
+
+						// Notify both players that the trade has succesfully ended
+						conn->send(SendTradeFinished(tradingBuddyId));
+						targetPlayer->send(SendTradeFinished(playerId));
+					}
+				}
 			}
 		}
 	}

--- a/src/essence.game/packets/lobby/outgoing/trading/SendTradeFinished.h
+++ b/src/essence.game/packets/lobby/outgoing/trading/SendTradeFinished.h
@@ -1,0 +1,10 @@
+#pragma once
+
+class SendTradeFinished : public LobbyServerPacket
+{
+public:
+	explicit SendTradeFinished(const uint32_t targetPlayerId) : LobbyServerPacket(892)
+	{
+		writeInt(targetPlayerId);
+	}
+};

--- a/src/essence.game/qpang/player/inventory/InventoryManager.cpp
+++ b/src/essence.game/qpang/player/inventory/InventoryManager.cpp
@@ -511,6 +511,10 @@ void InventoryManager::tradeCard(InventoryCard& card, const std::shared_ptr<Play
 	);
 
 	our->getEquipmentManager()->save();
+
+	card.isOpened = false;
+	card.playerOwnerId = player->getId();
+	player->getInventoryManager()->addCard(card);
 }
 
 void InventoryManager::giftCard(InventoryCard& card, const std::shared_ptr<Player>& player)

--- a/src/essence.game/qpang/player/inventory/InventoryManager.cpp
+++ b/src/essence.game/qpang/player/inventory/InventoryManager.cpp
@@ -476,6 +476,43 @@ bool InventoryManager::hasSpace() const
 	return m_cards.size() + m_gifts.size() < 200;
 }
 
+void InventoryManager::tradeCard(InventoryCard& card, const std::shared_ptr<Player>& player)
+{
+	const auto our = m_player.lock();
+
+	if (our == nullptr)
+		return;
+
+	std::lock_guard lg(m_mx);
+
+	auto cardOwnerPlayer = Game::instance()->getPlayer(card.playerOwnerId);
+
+	m_cards.erase(card.id);
+	card.timeCreated = time(nullptr);
+
+	DATABASE_DISPATCHER->dispatch(
+		"UPDATE player_items SET player_id = ?, opened = 0, time = ? WHERE id = ?",
+		{
+			player->getId(),
+			card.timeCreated,
+			card.id
+		}
+	);
+
+	DATABASE_DISPATCHER->dispatch(
+		"INSERT INTO player_gifts (player_from_id, player_from_name, player_to_id, player_to_name, card_id) VALUES(?, ?, ?, ?, ?)",
+		{
+			cardOwnerPlayer->getId(),
+			cardOwnerPlayer->getName(),
+			player->getId(),
+			player->getName(),
+			card.id,
+		}
+	);
+
+	our->getEquipmentManager()->save();
+}
+
 void InventoryManager::giftCard(InventoryCard& card, const std::shared_ptr<Player>& player)
 {
 	const auto our = m_player.lock();

--- a/src/essence.game/qpang/player/inventory/InventoryManager.h
+++ b/src/essence.game/qpang/player/inventory/InventoryManager.h
@@ -31,6 +31,8 @@ public:
 	bool hasSpace(uint32_t space) const;
 	bool hasSpace() const;
 
+	void tradeCard(InventoryCard& card, const std::shared_ptr<Player>& player);
+
 	void giftCard(InventoryCard& card, const std::shared_ptr<Player>& player);
 	void receiveGift(InventoryCard& card, const std::u16string& sender);
 	void openGift(uint64_t cardId);

--- a/src/essence.game/qpang/trading/TradeManager.cpp
+++ b/src/essence.game/qpang/trading/TradeManager.cpp
@@ -1,47 +1,38 @@
 #include "TradeManager.h"
 
-bool TradeManager::isTrading(const uint32_t playerId)
+bool TradeManager::isTrading(uint32_t userId) 
 {
-	const auto it = m_tradeSessions.find(playerId);
-
-	return (it != m_tradeSessions.end() && !it->second->isPending());
+	return m_tradeSessions.count(userId) && !m_tradeSessions[userId].isPending();
 }
 
-bool TradeManager::isPendingTradeSession(const uint32_t playerId)
+void TradeManager::startTradeSession(uint32_t userId, uint32_t targetUserId, bool isPending)
 {
-	const auto it = m_tradeSessions.find(playerId);
+	m_tradeSessions[userId] = TradeSessionInfo(targetUserId, isPending);
+}
 
-	if (it != m_tradeSessions.end())
+void TradeManager::endTradeSession(uint32_t userId)
+{
+	if (m_tradeSessions.count(userId))
 	{
-		return (it->second->isPending());
+		m_tradeSessions.erase(userId);
+	}
+}
+
+bool TradeManager::acceptTradeSession(uint32_t userId, uint32_t targetUserId)
+{
+	if (!m_tradeSessions.count(targetUserId))
+	{
+		return false;
 	}
 
-	return false;
+	// Update requester trade session to not be pending anymore
+	m_tradeSessions[targetUserId].setPending(false);
+
+	// Add trade session to requestor for the current userid
+	m_tradeSessions[userId] = TradeSessionInfo(targetUserId, false);
 }
 
-void TradeManager::startTradeSession(const uint32_t playerId, const uint32_t buddyId, const bool isPending)
+TradeSessionInfo& TradeManager::getTradeSessionInfo(uint32_t userId)
 {
-	m_tradeSessions[playerId] = new TradeSessionInfo(buddyId, isPending);
-}
-
-void TradeManager::endTradeSession(const uint32_t playerId)
-{
-	m_tradeSessions.erase(playerId);
-}
-
-TradeSessionInfo TradeManager::getTradeSessionInfo(const uint32_t playerId)
-{
-	return *m_tradeSessions[playerId];
-}
-
-uint32_t TradeManager::findTradingBuddyId(const uint32_t playerId)
-{
-	const auto it = m_tradeSessions.find(playerId);
-
-	if (it != m_tradeSessions.end())
-	{
-		return it->second->getBuddyId();
-	}
-
-	return 0;
+	return m_tradeSessions[userId];
 }

--- a/src/essence.game/qpang/trading/TradeManager.cpp
+++ b/src/essence.game/qpang/trading/TradeManager.cpp
@@ -32,6 +32,18 @@ bool TradeManager::acceptTradeSession(uint32_t userId, uint32_t targetUserId)
 	m_tradeSessions[userId] = TradeSessionInfo(targetUserId, false);
 }
 
+std::vector<uint32_t> TradeManager::getUsersRequestingTrade(uint32_t targetUserId)
+{
+	std::vector<uint32_t> requests = {};
+	for (auto tradeSession : m_tradeSessions)
+	{
+		if (tradeSession.second.getBuddyId() == targetUserId && tradeSession.second.isPending())
+			requests.push_back(tradeSession.first);
+	}
+
+	return requests;
+}
+
 TradeSessionInfo& TradeManager::getTradeSessionInfo(uint32_t userId)
 {
 	return m_tradeSessions[userId];

--- a/src/essence.game/qpang/trading/TradeManager.h
+++ b/src/essence.game/qpang/trading/TradeManager.h
@@ -7,37 +7,11 @@
 class TradeManager
 {
 public:
-#pragma region TradeSessions
-	/// <summary>
-	/// Determines whether or not a player is in a trade.
-	/// </summary>
-	bool isTrading(const uint32_t playerId);
-
-	/// <summary>
-	/// Determines whether or not a trade session is pending.
-	/// </summary>
-	bool isPendingTradeSession(const uint32_t playerId);
-
-	/// <summary>
-	/// Starts the trading session for two players.
-	/// </summary>
-	void startTradeSession(const uint32_t playerId, const uint32_t buddyId, const bool isPending);
-
-	/// <summary>
-	/// Ends the trading session for a player.
-	/// </summary>
-	void endTradeSession(const uint32_t playerId);
-
-	TradeSessionInfo getTradeSessionInfo(const uint32_t playerId);
-#pragma endregion
-
-#pragma region TradingBuddy
-	/// <summary>
-	/// Finds the corresponding trading buddy in the trading session.
-	/// </summary>
-	uint32_t findTradingBuddyId(const uint32_t playerId);
-#pragma endregion
-
+	bool isTrading(uint32_t userId);
+	void startTradeSession(uint32_t userId, uint32_t targetUserId, bool isPending);
+	void endTradeSession(uint32_t userId);
+	bool acceptTradeSession(uint32_t userId, uint32_t targetUserId);
+	TradeSessionInfo& getTradeSessionInfo(uint32_t userId);
 private:
-	std::map<uint32_t, TradeSessionInfo*> m_tradeSessions;
+	std::map<uint32_t, TradeSessionInfo> m_tradeSessions;
 };

--- a/src/essence.game/qpang/trading/TradeManager.h
+++ b/src/essence.game/qpang/trading/TradeManager.h
@@ -11,6 +11,8 @@ public:
 	void startTradeSession(uint32_t userId, uint32_t targetUserId, bool isPending);
 	void endTradeSession(uint32_t userId);
 	bool acceptTradeSession(uint32_t userId, uint32_t targetUserId);
+
+	std::vector<uint32_t> getUsersRequestingTrade(uint32_t targetUserId);
 	TradeSessionInfo& getTradeSessionInfo(uint32_t userId);
 private:
 	std::map<uint32_t, TradeSessionInfo> m_tradeSessions;

--- a/src/essence.game/qpang/trading/session/TradeSessionInfo.cpp
+++ b/src/essence.game/qpang/trading/session/TradeSessionInfo.cpp
@@ -1,5 +1,23 @@
 #include "TradeSessionInfo.h"
 
+void TradeSessionInfo::addCard(uint64_t cardToAdd)
+{
+    proposedCards.push_back(cardToAdd);
+}
+
+bool TradeSessionInfo::removeCard(uint64_t cardToRemove)
+{
+    auto pos = std::find(proposedCards.begin(), proposedCards.end(), cardToRemove);
+    if (pos != proposedCards.end())
+    {
+        proposedCards.erase(pos);
+        return true;
+    }
+
+    // Card wasn't added in the first place?
+    return false;
+}
+
 uint32_t TradeSessionInfo::getBuddyId()
 {
     return m_buddyId;
@@ -10,7 +28,22 @@ bool TradeSessionInfo::isPending()
     return m_isPending;
 }
 
-bool TradeSessionInfo::hasLockedIn()
+void TradeSessionInfo::setFinished(bool isFinished)
 {
-    return m_hasLockedIn;
+    m_isFinished = isFinished;
+}
+
+bool TradeSessionInfo::isFinished()
+{
+    return m_isFinished;
+}
+
+void TradeSessionInfo::setPending(bool isPending)
+{
+	m_isPending = isPending;
+}
+
+std::vector<uint64_t> TradeSessionInfo::getProposedCards()
+{
+    return proposedCards;
 }

--- a/src/essence.game/qpang/trading/session/TradeSessionInfo.h
+++ b/src/essence.game/qpang/trading/session/TradeSessionInfo.h
@@ -6,24 +6,33 @@
 class TradeSessionInfo
 {
 public:
+	TradeSessionInfo() {}
+
 	TradeSessionInfo(const uint32_t buddyId, const bool isPending)
 	{
 		m_buddyId = buddyId;
 		m_isPending = isPending;
 	}
 
+	void addCard(uint64_t cardToAdd);
+
+	bool removeCard(uint64_t cardToRemove);
+
 	uint32_t getBuddyId();
+
+	void setPending(bool isPending);
 
 	bool isPending();
 
-	bool hasLockedIn();
+	void setFinished(bool isFinished);
+
+	bool isFinished();
+
+	std::vector<uint64_t> getProposedCards();
 
 private:
-	uint32_t m_buddyId;
-
-	bool m_isPending;
-	
-	bool m_hasLockedIn;
-
-	std::vector<InventoryCard> cards{};
+	uint32_t m_buddyId = 0;
+	bool m_isPending = false;
+	bool m_isFinished = false;
+	std::vector<uint64_t> proposedCards{};
 };


### PR DESCRIPTION
Lobby trading should now be fully fixed and implemented.
List of features that I've worked on:

- Trades get canceled when one person leaves the game
- Trade request can be cancelled/accepted
- When accepting a trade, if the user has other incoming trade requests, those will be cancelled
- When trading, the trade can be cancelled
- When trading, cards can be added & removed
- When trading, the cards can be locked
- When trading, the trade can be finished, whilst waiting for the other person to also finish
- When the trade has finished, cards (with opened set to false) will be transferred between inventories, and the inventories will be updated instantly